### PR TITLE
Update to Python 3.8

### DIFF
--- a/overlay/usr/local/etc/rc.d/deluge_web
+++ b/overlay/usr/local/etc/rc.d/deluge_web
@@ -34,9 +34,9 @@ name="deluge_web"
 rcvar=${name}_enable
 
 command=/usr/local/bin/deluge-web
-#command_interpreter=/usr/local/bin/python3.7
+#command_interpreter=/usr/local/bin/python3.8
 
-procname="/usr/local/bin/python3.7"
+procname="/usr/local/bin/python3.8"
 pidfile="/var/run/${name}/pid"
 
 start_precmd=${name}_prestart

--- a/overlay/usr/local/etc/rc.d/deluged
+++ b/overlay/usr/local/etc/rc.d/deluged
@@ -34,7 +34,7 @@ name="deluged"
 rcvar=deluged_enable
 
 command=/usr/local/bin/${name}
-command_interpreter=/usr/local/bin/python3.7
+command_interpreter=/usr/local/bin/python3.8
 
 pidfile=/var/run/${name}/pid
 

--- a/post_install.sh
+++ b/post_install.sh
@@ -13,7 +13,7 @@ pip install --upgrade pip
 pip install deluge
 
 # Install fix for https://dev.deluge-torrent.org/ticket/3278
-patch -F 0 /usr/local/lib/python3.7/site-packages/deluge/argparserbase.py /usr/local/etc/deluge_changeset_1b4ac88ce.patch
+patch -F 0 /usr/local/lib/python3.8/site-packages/deluge/argparserbase.py /usr/local/etc/deluge_changeset_1b4ac88ce.patch
 
 # Configure the services
 sysrc -f /etc/rc.conf deluged_enable="YES"


### PR DESCRIPTION
Default Python is now 3.8. Package has been updated.

Ally Python 3.7 references updated to 3.8